### PR TITLE
Update get-release-url.sh for PL/24/ZTM-Katowice

### DIFF
--- a/PL/24/ZTM-Katowice/get-release-url.sh
+++ b/PL/24/ZTM-Katowice/get-release-url.sh
@@ -6,7 +6,7 @@
 
 RELEASE_URL=$(curl --connect-timeout 30 -s https://otwartedane.metropoliagzm.pl/dataset/86b5ce0c-daea-4b40-bc60-af2c80477d21.jsonld | \
               jq ' ."@graph"[]."dcat:accessURL"."@id"'                                                                              | \
-              fgrep 'schedule'                                                                                                      | \
+              fgrep 'schedule_2'                                                                                                    | \
               sed -e 's/^"//' -e 's/"$//' -e 's/^\(.*\)\(schedule.*\)$/\2 \1/'                                                      | \
               sort -r                                                                                                               | \
               head -1                                                                                                               | \


### PR DESCRIPTION
Fix error caused by filename change.
`schedule_ztm_2023.12.19_1528_0039.zip` is considered newer than `schedule_2024.03.11_1710143975000_1801.ext_gtfs.zip` because of `_ztm` suffix,