### PR TITLE
Update get-release-url.sh (CH 2025 timetable)

### DIFF
--- a/CH/Alle/get-release-url.sh
+++ b/CH/Alle/get-release-url.sh
@@ -4,7 +4,7 @@
 # get URL to download latest GTFS feed
 #
 
-PERMALINK="https://opentransportdata.swiss/de/dataset/timetable-2024-gtfs2020/permalink"
+PERMALINK="https://opentransportdata.swiss/de/dataset/timetable-2025-gtfs2020/permalink"
 
 LOCATION=$(curl --connect-timeout 30 -sI $PERMALINK | fgrep -i 'Location:' | sed -e 's/^Location:\s*//i' -e 's/\r$//')
 


### PR DESCRIPTION
CH-GTFS-Feed (permalink) updated to new 2025 timetable.