### PR TITLE
Change feed mirror for Zarząd Transportu Metropolitalnego

### DIFF
--- a/PL/24/ZTM-Katowice/get-release-date.sh
+++ b/PL/24/ZTM-Katowice/get-release-date.sh
@@ -4,5 +4,5 @@
 # retrieve release date of latest GTFS feed in form "YYYY-MM-DD"
 #
 
-echo $(curl -s https://api.github.com/repos/gtfs-proxies/24-ZTM-Katowice/releases/latest | \
+echo $(curl -s https://api.github.com/repos/TransportGZM-GTFS-mirror/TransportGZM-GTFS-extended-ver/releases/latest | \
        jq -r '.assets[0].updated_at[0:10]')

--- a/PL/24/ZTM-Katowice/get-release-url.sh
+++ b/PL/24/ZTM-Katowice/get-release-url.sh
@@ -4,5 +4,5 @@
 # get URL to download latest GTFS feed
 #
 
-echo $(curl -s https://api.github.com/repos/gtfs-proxies/24-ZTM-Katowice/releases/latest | \
+echo $(curl -s https://api.github.com/repos/TransportGZM-GTFS-mirror/TransportGZM-GTFS-extended-ver/releases/latest | \
        jq -r '.assets[0].browser_download_url')


### PR DESCRIPTION
The currently used feed mirror for ZTM seems to be not very actively maintained.

The one I'm suggesting in this PR has up-to-date data and is already being utilized by Transitland.