### PR TITLE
Fix path for Serbia/Belgrade release URL

### DIFF
--- a/RS/00/BGPREVOZ/get-release-url.sh
+++ b/RS/00/BGPREVOZ/get-release-url.sh
@@ -10,7 +10,7 @@ LOCATION=$(curl --connect-timeout 30 -sI $PERMALINK | grep -F -i 'Location:' | s
 
 if [ -n "$LOCATION" ]
 then
-    if [ "$(echo $LOCATION | grep -c '^https://data.gov.rs/s/resources/gtfs/.*\.zip$')" == 1 ]
+    if [ "$(echo $LOCATION | grep -c '^https://data.gov.rs/s/resources/.*\.zip$')" == 1 ]
     then
         RELEASE_URL=$LOCATION
     fi


### PR DESCRIPTION
City of Belgrade (finally) started releasing GTFS. I noticed that they changed URL and PTNA seems to not be able to catch it.

Now path seems to be in form of "https://data.gov.rs/s/resources/gradski-javni-prevoz-u-beogradu-gtfs/20250701-153434/gtfs-grad.zip" and removing "/gtfs" part of path seems to fix it. I didn't want to change it to "/gradski-javni-prevoz-u-beogradu-gtfs" as it might also change