### PR TITLE
Add GTFS feed for SNCF

### DIFF
--- a/FR/SNCF/cleanup.sh
+++ b/FR/SNCF/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#
+# delete temporary files
+#
+
+rm -rf tempdir 20[0-9][0-9]-[0-1][0-9]-[0-3][0-9]*

--- a/FR/SNCF/get-feed-name.sh
+++ b/FR/SNCF/get-feed-name.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#
+# print name of GTFS feed
+#
+
+echo "FR-SNCF"

--- a/FR/SNCF/get-release-date.sh
+++ b/FR/SNCF/get-release-date.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# retrieve release date of latest GTFS feed in form "YYYY-MM-DD"
+#
+
+RELEASE_URL=$(./get-release-url.sh)
+
+if [ -n "$RELEASE_URL" ]
+then
+    LAST_MODIFIED=$(curl --connect-timeout 30 -sI $RELEASE_URL | grep -F -i 'last-modified:' | sed -e 's/^last-modified:\s*//i')
+
+    if [ -n "$LAST_MODIFIED" ]
+    then
+        result=$(date -d "$LAST_MODIFIED" '+%Y-%m-%d')
+        if [ "$(echo $result | grep -c '^20[0-9][0-9]-[01][0-9]-[0123][0-9]$')" == 1 ]
+        then
+            RELEASE_DATE=$result
+        fi
+    fi
+fi
+
+echo $RELEASE_DATE

--- a/FR/SNCF/get-release-url.sh
+++ b/FR/SNCF/get-release-url.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#
+# get URL to download latest GTFS feed
+#
+
+echo "https://eu.ftp.opendatasoft.com/sncf/plandata/export-opendata-sncf-gtfs.zip"

--- a/FR/SNCF/osm.txt
+++ b/FR/SNCF/osm.txt
@@ -1,0 +1,2 @@
+id,prepared,network,network_short,network_guid,gtfs_agency_is_operator,trip_id_regex,gtfs_short_name_hack1,ptna_analysis
+1,"","","","",1,"^[^\.]+\.[^\.]+\.([^\.]+\.[^\.]+\.[^\.]+)$",1,FR-SNCF

--- a/FR/SNCF/ptna.txt
+++ b/FR/SNCF/ptna.txt
@@ -1,0 +1,2 @@
+id,language,network_name,network_name_url,prepared,aggregated,analyzed,normalized,feed_publisher_name,feed_publisher_url,release_date,release_url,license,license_url,original_license,original_license_url,has_shapes,consider_calendar,comment,details
+1,"fr","SNCF Voyageurs","https://www.sncf-voyageurs.com/","","","","","SNCF Voyageurs","https://ressources.data.sncf.com/explore/dataset/horaires-sncf/","","https://eu.ftp.opendatasoft.com/sncf/plandata/export-opendata-sncf-gtfs.zip","ODBL","https://data.sncf.com/pages/cgu/A1","","",0,0,"","Details ..."


### PR DESCRIPTION
The french railway company SNCF delivers a unique GTFS feed for the whole network, under an ODBL license: https://ressources.data.sncf.com/explore/dataset/horaires-sncf/information/

This ZIP file includes high speed trains (TGV), intercity trains (Intercités) and regional trains (TER) that are operated by SNCF Voyageurs or one of its branch, excluding trains that are operated by a concurrent firm (Transdev for the line K1+ Marseille/Nice/Vintimille, Trenitalia France between Paris and Lyon/Milano/Marseille, Renfe for the lines Lyon/Barcelona and Marseille/Madrid).

Trains in the Paris suburban area "Transilien" are also not included in this file. They are either available in a dedicated dataset (https://ressources.data.sncf.com/explore/dataset/sncf-transilien-gtfs/) of included in the whole dataset of the region transport authority "Île-de-France Mobilités" (https://data.iledefrance-mobilites.fr/explore/dataset/offre-horaires-tc-gtfs-idfm/information/), but this may be useful in another project.

As a french train lover, I am working to fix train routes on OSM, as they are most often quite old and using PTv1 scheme. I will probably submit a PR on the ptna-networks repository in the few days to analyse each train line (one page for national lines and one page per region).

I used the code FR-SNCF, I don't know if this is the right one.