### PR TITLE
Update SNCF GTFS URL

### DIFF
--- a/FR/SNCF/get-release-url.sh
+++ b/FR/SNCF/get-release-url.sh
@@ -4,4 +4,4 @@
 # get URL to download latest GTFS feed
 #
 
-echo "https://eu.ftp.opendatasoft.com/sncf/plandata/export-opendata-sncf-gtfs.zip"
+echo "https://eu.ftp.opendatasoft.com/sncf/plandata/Export_OpenData_SNCF_GTFS_NewTripId.zip"


### PR DESCRIPTION
Hi,

The URL for the SNCF GTFS file was changed last year, the new URL is now: https://eu.ftp.opendatasoft.com/sncf/plandata/Export_OpenData_SNCF_GTFS_NewTripId.zip

I'm not exactly sure why, but I think the format of the route IDs was changed and standardized.